### PR TITLE
tc: {m_gate,q_etf,q_taprio}.c: fix compilation with older glibc versions

### DIFF
--- a/tc/m_gate.c
+++ b/tc/m_gate.c
@@ -26,8 +26,12 @@ static const struct clockid_table {
 	clockid_t clockid;
 } clockt_map[] = {
 	{ "REALTIME", CLOCK_REALTIME },
+#ifdef CLOCK_TAI
 	{ "TAI", CLOCK_TAI },
+#endif
+#ifdef CLOCK_BOOTTIME
 	{ "BOOTTIME", CLOCK_BOOTTIME },
+#endif
 	{ "MONOTONIC", CLOCK_MONOTONIC },
 	{ NULL }
 };

--- a/tc/q_etf.c
+++ b/tc/q_etf.c
@@ -25,8 +25,12 @@ static const struct static_clockid {
 	clockid_t clockid;
 } clockids_sysv[] = {
 	{ "REALTIME", CLOCK_REALTIME },
+#ifdef CLOCK_TAI
 	{ "TAI", CLOCK_TAI },
+#endif
+#ifdef CLOCK_BOOTTIME
 	{ "BOOTTIME", CLOCK_BOOTTIME },
+#endif
 	{ "MONOTONIC", CLOCK_MONOTONIC },
 	{ NULL }
 };

--- a/tc/q_taprio.c
+++ b/tc/q_taprio.c
@@ -35,8 +35,12 @@ static const struct static_clockid {
 	clockid_t clockid;
 } clockids_sysv[] = {
 	{ "REALTIME", CLOCK_REALTIME },
+#ifdef CLOCK_TAI
 	{ "TAI", CLOCK_TAI },
+#endif
+#ifdef CLOCK_BOOTTIME
 	{ "BOOTTIME", CLOCK_BOOTTIME },
+#endif
 	{ "MONOTONIC", CLOCK_MONOTONIC },
 	{ NULL }
 };


### PR DESCRIPTION
glibc < 2.14 does not define CLOCK_BOOTTIME
glibc < 2.21 does not define CLOCK_TAI