### PR TITLE
musl: include <limits.h> for PATH_MAX macro

### DIFF
--- a/ip/iplink.c
+++ b/ip/iplink.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <stdbool.h>
+#include <limits.h>
 #include <linux/mpls.h>
 
 #include "rt_names.h"

--- a/ip/ipnetns.c
+++ b/ip/ipnetns.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <limits.h>
 #include <linux/limits.h>
 
 #include <linux/net_namespace.h>


### PR DESCRIPTION
https://bugs.gentoo.org/946088